### PR TITLE
[feat&fix][*][v0.1.2] downgrade fastjson to `1.2.83_noneautotype` and add `txHash` to `CrossChainReceipt`

### DIFF
--- a/antchain-bridge-commons/pom.xml
+++ b/antchain-bridge-commons/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alipay.antchain.bridge</groupId>
     <artifactId>antchain-bridge-commons</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>2.0.21</version>
+            <version>1.2.83_noneautotype</version>
         </dependency>
         <dependency>
             <groupId>cn.hutool</groupId>

--- a/antchain-bridge-commons/src/main/java/com/alipay/antchain/bridge/commons/core/base/CrossChainMessage.java
+++ b/antchain-bridge-commons/src/main/java/com/alipay/antchain/bridge/commons/core/base/CrossChainMessage.java
@@ -55,6 +55,8 @@ public class CrossChainMessage {
         private byte[] ledgerData;
 
         private byte[] proof;
+
+        private byte[] txHash;
     }
 
     public static CrossChainMessage createCrossChainMessage(
@@ -64,7 +66,8 @@ public class CrossChainMessage {
             byte[] blockHash,
             byte[] message,
             byte[] ledgerData,
-            byte[] proof
+            byte[] proof,
+            byte[] txHash
     ) {
         CrossChainMessage msg = new CrossChainMessage();
         msg.setType(type);
@@ -75,6 +78,7 @@ public class CrossChainMessage {
         provableLedgerData.setBlockHash(blockHash);
         provableLedgerData.setHeight(height);
         provableLedgerData.setTimestamp(timestamp);
+        provableLedgerData.setTxHash(txHash);
         msg.setProvableData(provableLedgerData);
 
         return msg;

--- a/antchain-bridge-plugin-lib/pom.xml
+++ b/antchain-bridge-plugin-lib/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alipay.antchain.bridge</groupId>
     <artifactId>antchain-bridge-plugin-lib</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/antchain-bridge-plugin-manager/pom.xml
+++ b/antchain-bridge-plugin-manager/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alipay.antchain.bridge</groupId>
     <artifactId>antchain-bridge-plugin-manager</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -18,12 +18,12 @@
         <dependency>
             <groupId>com.alipay.antchain.bridge</groupId>
             <artifactId>antchain-bridge-plugin-lib</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
         <dependency>
             <groupId>com.alipay.antchain.bridge</groupId>
             <artifactId>antchain-bridge-spi</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <dependency>

--- a/antchain-bridge-spi/pom.xml
+++ b/antchain-bridge-spi/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alipay.antchain.bridge</groupId>
     <artifactId>antchain-bridge-spi</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.alipay.antchain.bridge</groupId>
             <artifactId>antchain-bridge-commons</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pluginset/demo-testchain/offchain-plugin/pom.xml
+++ b/pluginset/demo-testchain/offchain-plugin/pom.xml
@@ -27,12 +27,12 @@
         <dependency>
             <groupId>com.alipay.antchain.bridge</groupId>
             <artifactId>antchain-bridge-plugin-lib</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
         <dependency>
             <groupId>com.alipay.antchain.bridge</groupId>
             <artifactId>antchain-bridge-spi</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pluginset/demo-testchain/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/demo/testchain/MockDataUtils.java
+++ b/pluginset/demo-testchain/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/demo/testchain/MockDataUtils.java
@@ -50,7 +50,8 @@ public class MockDataUtils {
                 DigestUtil.sha256(height.toString()),
                 generateAM().encode(),
                 ledgerData,
-                proof
+                proof,
+                DigestUtil.sha256(height.toString())
         );
     }
 }

--- a/pluginset/demo-testchain/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/demo/testchain/TestChainBBCService.java
+++ b/pluginset/demo-testchain/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/demo/testchain/TestChainBBCService.java
@@ -169,7 +169,8 @@ public class TestChainBBCService implements IBBCService {
                         // put the ledger data inside, just for SPV or other attestations
                         testChainReceipt.toBytes(),
                         // this time we need no proof data. it's ok to set it with empty bytes
-                        "pretend that we have merkle proof or some stuff".getBytes()
+                        "pretend that we have merkle proof or some stuff".getBytes(),
+                        testChainReceipt.getTxhash().getBytes()
                 )
         ).collect(Collectors.toList());
     }

--- a/pluginset/demo-testchain/plugin-loader/pom.xml
+++ b/pluginset/demo-testchain/plugin-loader/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.alipay.antchain.bridge</groupId>
             <artifactId>antchain-bridge-plugin-manager</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
 
         <!-- Logging -->

--- a/pluginset/eos/offchain-plugin/pom.xml
+++ b/pluginset/eos/offchain-plugin/pom.xml
@@ -32,12 +32,12 @@
         <dependency>
             <groupId>com.alipay.antchain.bridge</groupId>
             <artifactId>antchain-bridge-plugin-lib</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
         <dependency>
             <groupId>com.alipay.antchain.bridge</groupId>
             <artifactId>antchain-bridge-spi</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pluginset/eos/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/eos/EosBBCService.java
+++ b/pluginset/eos/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/eos/EosBBCService.java
@@ -440,7 +440,8 @@ public class EosBBCService implements IBBCService {
                                             // this time we need no verify. it's ok to set it with empty bytes
                                             new byte[]{},
                                             // this time we need no proof data. it's ok to set it with empty bytes
-                                            new byte[]{}
+                                            new byte[]{},
+                                            HexUtil.decodeHex(eosTxActions.getTxId())
                                     )
                             )
                     );

--- a/pluginset/ethereum/offchain-plugin/pom.xml
+++ b/pluginset/ethereum/offchain-plugin/pom.xml
@@ -27,12 +27,12 @@
         <dependency>
             <groupId>com.alipay.antchain.bridge</groupId>
             <artifactId>antchain-bridge-plugin-lib</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
         </dependency>
         <dependency>
             <groupId>com.alipay.antchain.bridge</groupId>
             <artifactId>antchain-bridge-spi</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pluginset/ethereum/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/ethereum/EthereumBBCService.java
+++ b/pluginset/ethereum/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/ethereum/EthereumBBCService.java
@@ -232,7 +232,8 @@ public class EthereumBBCService implements IBBCService {
                                 // todo: put ledger data, for SPV or other attestations
                                 "this time we need no verify. it's ok to set it with empty bytes".getBytes(),
                                 // todo: put proof data
-                                "this time we need no proof data. it's ok to set it with empty bytes".getBytes()
+                                "this time we need no proof data. it's ok to set it with empty bytes".getBytes(),
+                                HexUtil.decodeHex(logObject.getTransactionHash())
                         )
                 ).collect(Collectors.toList()));
             }

--- a/scripts/print.sh
+++ b/scripts/print.sh
@@ -6,7 +6,7 @@ WHITE='\033[1;37m'
 NC='\033[0m'
 LIGHT_GRAY='\033[0;37m'
 
-SDK_VERSION='0.1.1'
+SDK_VERSION='0.1.2'
 
 function print_blue() {
   printf "${BLUE}%s${NC}\n" "$1"


### PR DESCRIPTION
- downgrade fastjson to `1.2.83_noneautotype` to avoid the vulnerability
- new field `txHash` for `CrossChainReceipt` that needed by `Relayer`
