### PR TITLE
[fix][IVerifierWriter][v0.1.0] make updatePTCTrustRoot default to allow BBCService version detection

### DIFF
--- a/acb-sdk/antchain-bridge-spi/src/main/java/com/alipay/antchain/bridge/plugins/spi/bbc/core/write/IVerifierWriter.java
+++ b/acb-sdk/antchain-bridge-spi/src/main/java/com/alipay/antchain/bridge/plugins/spi/bbc/core/write/IVerifierWriter.java
@@ -33,7 +33,11 @@ public interface IVerifierWriter {
      *
      * @param ptcTrustRoot {@link PTCTrustRoot}
      */
-    void updatePTCTrustRoot(PTCTrustRoot ptcTrustRoot);
+    default void updatePTCTrustRoot(PTCTrustRoot ptcTrustRoot) {
+        throw new UnsupportedOperationException(
+                "updatePTCTrustRoot is not supported in BBC V0"
+        );
+    };
 
     /**
      * Add raw <b>Third-Party Blockchain Trust Anchor</b>


### PR DESCRIPTION
#### 修改内容

`com.alipay.antchain.bridge.plugins.spi.bbc.core.write.IVerifierWriter的updatePTCTrustRoot`抽象接口，在其定义前新增`default`关键字

##### 修改原因

`com.alipay.antchain.bridge.plugins.spi.utils.pf4j.Utils`中的`getBBCVersion`方法，是通过反射检查某个`IBBCService`实现类（即插件中）是否`override`了`updatePTCTrustRoot`方法，从而判断该`BBCService`属于V0还是V1版本。但由于`IBBCService`是声明的抽象类，在语法限制下，`BBCService`作为实现类，必须要对`IBBCService`中的所有方法（包括`updatePTCTrustRoot`）进行`override`，从而导致`getBBCVersion`的判断结果会固定为V1。

#### 修改结果

在`updatePTCTrustRoot`抽象接口中新增`default`关键字后，`BBCService`实现类中就能选择是否对`updatePTCTrustRoot`方法进行`override`，从而让`getBBCVersion`方法能够正确判断`BBCService`属于V0还是V1版本。