### PR TITLE
[fix][relayer][ddl] include lane key in anchor process uniqueness

### DIFF
--- a/acb-relayer/r-bootstrap/src/main/resources/db/ddl.sql
+++ b/acb-relayer/r-bootstrap/src/main/resources/db/ddl.sql
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS `anchor_process`
     `gmt_create`         datetime            DEFAULT CURRENT_TIMESTAMP,
     `gmt_modified`       datetime            DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`),
-    UNIQUE KEY `blockchain_product` (`blockchain_product`, `instance`, `task`)
+    UNIQUE KEY `anchor_process_unique_product_instance_task_lane` (`blockchain_product`, `instance`, `task`, `tpbta_lane_key`)
 ) ENGINE = InnoDB
   ROW_FORMAT = DYNAMIC;
 

--- a/acb-relayer/r-bootstrap/src/test/resources/data/ddl.sql
+++ b/acb-relayer/r-bootstrap/src/test/resources/data/ddl.sql
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS `anchor_process`
     `gmt_create`         datetime     DEFAULT CURRENT_TIMESTAMP,
     `gmt_modified`       datetime     DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`),
-    UNIQUE KEY `blockchain_product` (`blockchain_product`, `instance`, `task`)
+    UNIQUE KEY `anchor_process_unique_product_instance_task_lane` (`blockchain_product`, `instance`, `task`, `tpbta_lane_key`)
 );
 
 CREATE TABLE IF NOT EXISTS `domain_cert`


### PR DESCRIPTION
Anchor progress is lane-specific. In FISCO/TPBTA flows, the relayer can keep both an empty-lane progress row and a lane-specific progress row for the same blockchain product, instance, and task.

Without `tpbta_lane_key` in the unique key, those valid rows are treated as duplicates and can trigger `DuplicateKeyException`, blocking anchor height persistence.

- Update production DDL unique key on `anchor_process` from `(blockchain_product, instance, task)` to `(blockchain_product, instance, task, tpbta_lane_key)`.
