### PR TITLE
[fix][relayer][core] preserve blockchain properties on partial update

### DIFF
--- a/acb-relayer/r-bootstrap/src/test/java/com/alipay/antchain/bridge/relayer/bootstrap/manager/BlockchainManagerTest.java
+++ b/acb-relayer/r-bootstrap/src/test/java/com/alipay/antchain/bridge/relayer/bootstrap/manager/BlockchainManagerTest.java
@@ -119,6 +119,62 @@ public class BlockchainManagerTest extends TestBase {
     }
 
     @Test
+    public void testUpdateBlockchainPreservesPropertiesOnPartialConfig() {
+
+        BlockchainMeta blockchainMeta = blockchainManager.getBlockchainMetaByDomain(antChainDotComDomain);
+        String amAddr = "AM_CONTRACT_TO_KEEP";
+        String sdpAddr = "SDP_CONTRACT_TO_KEEP";
+        String ptcAddr = "PTC_CONTRACT_TO_KEEP";
+        long initBlockHeight = 12345L;
+
+        blockchainMeta.getProperties().setAmClientContractAddress(amAddr);
+        blockchainMeta.getProperties().setSdpMsgContractAddress(sdpAddr);
+        blockchainMeta.getProperties().setPtcContractAddress(ptcAddr);
+        blockchainMeta.getProperties().setInitBlockHeight(initBlockHeight);
+        blockchainMeta.getProperties().setIsDomainRegistered(true);
+        Assert.assertTrue(blockchainRepository.updateBlockchainMeta(blockchainMeta));
+
+        Map<String, String> partialClientConfig = new HashMap<>();
+        partialClientConfig.put(Constants.HETEROGENEOUS_BBC_CONTEXT, JSON.toJSONString(blockchainProperties1.getBbcContext()));
+        blockchainManager.updateBlockchain(
+                antChainDotComProduct,
+                antChainDotComBlockchainId,
+                "",
+                blockchainMeta.getAlias(),
+                blockchainMeta.getDesc(),
+                partialClientConfig
+        );
+
+        BlockchainMeta updatedMeta = blockchainManager.getBlockchainMetaByDomain(antChainDotComDomain);
+        Assert.assertEquals(PS_ID, updatedMeta.getPluginServerId());
+        Assert.assertEquals(initBlockHeight, updatedMeta.getProperties().getInitBlockHeight().longValue());
+        Assert.assertEquals(amAddr, updatedMeta.getProperties().getAmClientContractAddress());
+        Assert.assertEquals(sdpAddr, updatedMeta.getProperties().getSdpMsgContractAddress());
+        Assert.assertEquals(ptcAddr, updatedMeta.getProperties().getPtcContractAddress());
+        Assert.assertTrue(updatedMeta.getProperties().getIsDomainRegistered());
+
+        String newPtcAddr = "PTC_CONTRACT_UPDATED";
+        partialClientConfig.clear();
+        partialClientConfig.put("ptc_contract_address", newPtcAddr);
+        blockchainManager.updateBlockchain(
+                antChainDotComProduct,
+                antChainDotComBlockchainId,
+                "",
+                blockchainMeta.getAlias(),
+                blockchainMeta.getDesc(),
+                partialClientConfig
+        );
+
+        updatedMeta = blockchainManager.getBlockchainMetaByDomain(antChainDotComDomain);
+        Assert.assertEquals(PS_ID, updatedMeta.getPluginServerId());
+        Assert.assertEquals(initBlockHeight, updatedMeta.getProperties().getInitBlockHeight().longValue());
+        Assert.assertEquals(amAddr, updatedMeta.getProperties().getAmClientContractAddress());
+        Assert.assertEquals(sdpAddr, updatedMeta.getProperties().getSdpMsgContractAddress());
+        Assert.assertEquals(newPtcAddr, updatedMeta.getProperties().getPtcContractAddress());
+        Assert.assertTrue(updatedMeta.getProperties().getIsDomainRegistered());
+    }
+
+    @Test
     public void testUpdateBlockchainProperty() {
 
         blockchainManager.updateBlockchainProperty(

--- a/acb-relayer/r-commons/src/main/java/com/alipay/antchain/bridge/relayer/commons/model/BlockchainMeta.java
+++ b/acb-relayer/r-commons/src/main/java/com/alipay/antchain/bridge/relayer/commons/model/BlockchainMeta.java
@@ -164,6 +164,9 @@ public class BlockchainMeta {
         if (StrUtil.isNotEmpty(properties.getSdpMsgContractAddress())) {
             this.properties.setSdpMsgContractAddress(properties.getSdpMsgContractAddress());
         }
+        if (StrUtil.isNotEmpty(properties.getPtcContractAddress())) {
+            this.properties.setPtcContractAddress(properties.getPtcContractAddress());
+        }
         if (ObjectUtil.isNotNull(properties.getAnchorRuntimeStatus())) {
             this.properties.setAnchorRuntimeStatus(properties.getAnchorRuntimeStatus());
         }

--- a/acb-relayer/r-core/src/main/java/com/alipay/antchain/bridge/relayer/core/manager/blockchain/BlockchainManager.java
+++ b/acb-relayer/r-core/src/main/java/com/alipay/antchain/bridge/relayer/core/manager/blockchain/BlockchainManager.java
@@ -198,7 +198,7 @@ public class BlockchainManager implements IBlockchainManager {
             blockchainMeta.setAlias(alias);
             blockchainMeta.setDesc(desc);
             blockchainMeta.updateProperties(blockchainProperties);
-            if (!updateBlockchainMeta(new BlockchainMeta(product, blockchainId, alias, desc, blockchainProperties))) {
+            if (!updateBlockchainMeta(blockchainMeta)) {
                 throw new RuntimeException(
                         StrUtil.format(
                                 "failed to update meta for blockchain {} - {} into DB",


### PR DESCRIPTION
CLI/API updates may provide only a subset of blockchain properties, such as `heterogeneous_bbc_context`. The previous flow merged the partial config into the existing `BlockchainMeta`, but then persisted a newly constructed meta from only the partial properties. That could wipe fields that were not present in the update payload.

Affected fields include plugin server metadata, init block height, AM/SDP/PTC contract addresses, and domain registration state.

- Persist the merged `BlockchainMeta` in `BlockchainManager.updateBlockchain(...)`.
- Merge `ptc_contract_address` in `BlockchainMeta.updateProperties(...)`.