### PR TITLE
fix(ethereum2): validate light client committee updates

### DIFF
--- a/acb-sdk/pluginset/ethereum2/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/ethereum2/core/EthConsensusStateData.java
+++ b/acb-sdk/pluginset/ethereum2/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/ethereum2/core/EthConsensusStateData.java
@@ -192,8 +192,18 @@ public class EthConsensusStateData {
             Eth2ChainConfig eth2ChainConfig
     ) {
         var attestedHeader = lightClientUpdate.getAttestedHeader();
-        var sigPeriod = lightClientUpdate.getSignatureSlot().dividedBy(eth2ChainConfig.getSyncPeriodLength());
-        var attestedHeaderPeriod = attestedHeader.getBeacon().getSlot().dividedBy(eth2ChainConfig.getSyncPeriodLength());
+        var finalizedHeader = lightClientUpdate.getFinalizedHeader();
+        var signatureSlot = lightClientUpdate.getSignatureSlot();
+        var attestedSlot = attestedHeader.getBeacon().getSlot();
+        var finalizedSlot = finalizedHeader.getBeacon().getSlot();
+        if (signatureSlot.compareTo(attestedSlot) <= 0) {
+            throw new InvalidConsensusDataException("signature slot must be greater than attested header slot");
+        }
+        if (attestedSlot.compareTo(finalizedSlot) < 0) {
+            throw new InvalidConsensusDataException("attested header slot must not be less than finalized header slot");
+        }
+        var sigPeriod = signatureSlot.dividedBy(eth2ChainConfig.getSyncPeriodLength());
+        var attestedHeaderPeriod = attestedSlot.dividedBy(eth2ChainConfig.getSyncPeriodLength());
         if (!sigPeriod.equals(attestedHeaderPeriod)) {
             throw new InvalidConsensusDataException("sig slot period is not equal to attested header period");
         }
@@ -201,9 +211,21 @@ public class EthConsensusStateData {
         if (!sigPeriod.equals(currPeriod)) {
             throw new InvalidConsensusDataException("sig slot period is not equal to current committee period");
         }
+        var finalizedHeaderPeriod = finalizedSlot.dividedBy(eth2ChainConfig.getSyncPeriodLength());
+        if (!finalizedHeaderPeriod.equals(attestedHeaderPeriod)) {
+            throw new InvalidConsensusDataException("finalized header period is not equal to attested header period");
+        }
 
         var nextSyncCommittee = lightClientUpdate.getNextSyncCommittee();
         var syncAggregate = lightClientUpdate.getSyncAggregate();
+        if (currentSyncCommittee.getPubkeys().size() != syncAggregate.getSyncCommitteeBits().size()) {
+            throw new InvalidConsensusDataException("sync aggregate bits' size is not equal to current sync committee size");
+        }
+        if (syncAggregate.getSyncCommitteeBits().stream().filter(AbstractSszPrimitive::get).count()
+                < eth2ChainConfig.getSyncCommitteeSuperMajority()) {
+            throw new InvalidConsensusDataException("sync committee signature is not enough");
+        }
+
         List<BLSPublicKey> contributionPubkeys = new ArrayList<>();
         for (int i = 0; i < currentSyncCommittee.getPubkeys().size(); i++) {
             if (syncAggregate.getSyncCommitteeBits().getBit(i)) {
@@ -212,6 +234,9 @@ public class EthConsensusStateData {
         }
 
         var nextSyncCommitteeBranch = lightClientUpdate.getNextSyncCommitteeBranch();
+        if (nextSyncCommitteeBranch.size() != eth2ChainConfig.getSyncCommitteeBranchLength()) {
+            throw new InvalidConsensusDataException("next sync committee branch length is invalid");
+        }
         if (!new Predicates(null).isValidMerkleBranch(
                 nextSyncCommittee.hashTreeRoot(),
                 nextSyncCommitteeBranch,
@@ -219,13 +244,27 @@ public class EthConsensusStateData {
                 Eth2ConstantParams.STATE_INDEX_NEXT_SYNC_COMMITTEE,
                 attestedHeader.getBeacon().getStateRoot()
         )) {
-            throw new InvalidConsensusDataException("next sync committee branches is invalid");
+            throw new InvalidConsensusDataException("next sync committee branch is invalid");
+        }
+
+        var finalityBranch = lightClientUpdate.getFinalityBranch();
+        if (finalityBranch.size() != eth2ChainConfig.getFinalityBranchLength()) {
+            throw new InvalidConsensusDataException("finality branch length is invalid");
+        }
+        if (!new Predicates(null).isValidMerkleBranch(
+                finalizedHeader.getBeacon().hashTreeRoot(),
+                finalityBranch,
+                finalityBranch.size(),
+                Eth2ConstantParams.STATE_INDEX_FINAL_BLOCK,
+                attestedHeader.getBeacon().getStateRoot()
+        )) {
+            throw new InvalidConsensusDataException("finalized header merkle proof is invalid");
         }
 
         // verify sync committee signature
         var signingRoot = new SigningData(
                 attestedHeader.hashTreeRoot(),
-                Bytes32.wrap(eth2ChainConfig.getForkBySlot(getSyncCommitteeForkSlot(lightClientUpdate.getSignatureSlot())).getDomain())
+                Bytes32.wrap(eth2ChainConfig.getForkBySlot(getSyncCommitteeForkSlot(signatureSlot)).getDomain())
         ).hashTreeRoot();
         if (!BLSSignatureVerifier.SIMPLE.verify(
                 contributionPubkeys,

--- a/acb-sdk/pluginset/ethereum2/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/ethereum2/core/eth/LightClientUpdateWrapper.java
+++ b/acb-sdk/pluginset/ethereum2/offchain-plugin/src/main/java/com/alipay/antchain/bridge/plugins/ethereum2/core/eth/LightClientUpdateWrapper.java
@@ -25,6 +25,14 @@ public record LightClientUpdateWrapper(LightClientUpdate lightClientUpdate) {
         return (SszBytes32Vector) lightClientUpdate.get(2);
     }
 
+    public LightClientHeader getFinalizedHeader() {
+        return (LightClientHeader) lightClientUpdate.get(3);
+    }
+
+    public SszBytes32Vector getFinalityBranch() {
+        return (SszBytes32Vector) lightClientUpdate.get(4);
+    }
+
     public SyncAggregate getSyncAggregate() {
         return (SyncAggregate) lightClientUpdate.get(5);
     }

--- a/acb-sdk/pluginset/ethereum2/offchain-plugin/src/test/java/com/alipay/antchain/bridge/plugins/ethereum2/EthConsensusStateDataTest.java
+++ b/acb-sdk/pluginset/ethereum2/offchain-plugin/src/test/java/com/alipay/antchain/bridge/plugins/ethereum2/EthConsensusStateDataTest.java
@@ -1,0 +1,118 @@
+package com.alipay.antchain.bridge.plugins.ethereum2;
+
+import java.nio.charset.StandardCharsets;
+
+import cn.hutool.core.io.FileUtil;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import com.alipay.antchain.bridge.plugins.ethereum2.core.EthConsensusStateData;
+import com.alipay.antchain.bridge.plugins.ethereum2.core.InvalidConsensusDataException;
+import com.alipay.antchain.bridge.plugins.ethereum2.core.eth.LightClientUpdateWrapper;
+import com.alipay.antchain.bridge.plugins.ethereum2.core.eth.eth2spec.Eth2ChainConfig;
+import lombok.SneakyThrows;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.Test;
+import tech.pegasys.teku.infrastructure.json.JsonUtil;
+import tech.pegasys.teku.spec.datastructures.lightclient.LightClientUpdate;
+import tech.pegasys.teku.spec.datastructures.lightclient.LightClientUpdateSchema;
+import tech.pegasys.teku.spec.datastructures.state.SyncCommittee;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class EthConsensusStateDataTest {
+
+    private static final Eth2ChainConfig CHAIN_CONFIG = Eth2ChainConfig.MAINNET_CHAIN_CONFIG;
+
+    private static final SyncCommittee CURRENT_SYNC_COMMITTEE = new LightClientUpdateWrapper(
+            parseLightClientUpdate(loadUpdate("update.json"))
+    ).getNextSyncCommittee();
+
+    @Test
+    public void testValidateApplicableLightClientUpdate() {
+        var stateData = createStateData(loadUpdate("update-next-period.json"));
+
+        stateData.validateLightClientUpdate(CURRENT_SYNC_COMMITTEE, CHAIN_CONFIG);
+    }
+
+    @Test
+    public void testRejectLightClientUpdateWithoutSuperMajority() {
+        var update = loadUpdate("update-next-period.json");
+        var syncAggregate = update.getJSONObject("sync_aggregate");
+        var bits = syncAggregate.getString("sync_committee_bits");
+        var byteCount = (bits.length() - 2) / 2;
+        syncAggregate.put("sync_committee_bits", "0x01" + "00".repeat(byteCount - 1));
+
+        var exception = assertThrows(
+                InvalidConsensusDataException.class,
+                () -> createStateData(update).validateLightClientUpdate(CURRENT_SYNC_COMMITTEE, CHAIN_CONFIG)
+        );
+
+        assertEquals("sync committee signature is not enough", exception.getMessage());
+    }
+
+    @Test
+    public void testRejectLightClientUpdateWithInvalidFinalityBranch() {
+        var update = loadUpdate("update-next-period.json");
+        var finalityBranch = update.getJSONArray("finality_branch");
+        for (int i = 0; i < finalityBranch.size(); i++) {
+            finalityBranch.set(i, Bytes32.ZERO.toHexString());
+        }
+
+        var exception = assertThrows(
+                InvalidConsensusDataException.class,
+                () -> createStateData(update).validateLightClientUpdate(CURRENT_SYNC_COMMITTEE, CHAIN_CONFIG)
+        );
+
+        assertEquals("finalized header merkle proof is invalid", exception.getMessage());
+    }
+
+    @Test
+    public void testRejectLightClientUpdateWithInvalidSlotOrder() {
+        var update = loadUpdate("update-next-period.json");
+        update.put(
+                "signature_slot",
+                update.getJSONObject("attested_header").getJSONObject("beacon").getString("slot")
+        );
+
+        var exception = assertThrows(
+                InvalidConsensusDataException.class,
+                () -> createStateData(update).validateLightClientUpdate(CURRENT_SYNC_COMMITTEE, CHAIN_CONFIG)
+        );
+
+        assertEquals("signature slot must be greater than attested header slot", exception.getMessage());
+    }
+
+    @Test
+    public void testRejectNextCommitteeWithoutSamePeriodFinality() {
+        var update = loadUpdate("update-next-period.json");
+        update.getJSONObject("finalized_header").getJSONObject("beacon").put("slot", "0");
+
+        var exception = assertThrows(
+                InvalidConsensusDataException.class,
+                () -> createStateData(update).validateLightClientUpdate(CURRENT_SYNC_COMMITTEE, CHAIN_CONFIG)
+        );
+
+        assertEquals("finalized header period is not equal to attested header period", exception.getMessage());
+    }
+
+    private static EthConsensusStateData createStateData(JSONObject updateJson) {
+        var update = new LightClientUpdateWrapper(parseLightClientUpdate(updateJson));
+        var stateData = new EthConsensusStateData();
+        stateData.setBeaconBlockHeader(update.getAttestedHeader().getBeacon());
+        stateData.setLightClientUpdateWrapper(update);
+        return stateData;
+    }
+
+    @SneakyThrows
+    private static LightClientUpdate parseLightClientUpdate(JSONObject updateJson) {
+        return JsonUtil.parse(
+                updateJson.toJSONString(),
+                new LightClientUpdateSchema(CHAIN_CONFIG.getSpecConfig()).getJsonTypeDefinition()
+        );
+    }
+
+    private static JSONObject loadUpdate(String filename) {
+        return JSON.parseObject(FileUtil.readString(filename, StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Summary

- require sync committee supermajority before accepting a next committee
- validate signature, attested, and finalized slot/period relationships
- verify the finalized header Merkle proof and configured branch lengths
- add positive and adversarial light client update regression tests

## Testing

- `mvn -Dtest=EthDataTest,BeaconTest,EthereumHcdvsTest,EthConsensusStateDataTest test`
- 26 tests passed

Follow-up security hardening for #75.